### PR TITLE
Fix failing test due to bad reference

### DIFF
--- a/pkg/examplepkg/exampletype_test.go
+++ b/pkg/examplepkg/exampletype_test.go
@@ -32,7 +32,7 @@ func (s *exampletypeSuite) TearDownTest() {
 
 func (s *exampletypeSuite) TestMyFunc() {
 	// If the following statement fails, the test will end immediately
-	s.Require().Equal(s.myt.PublicVal, testVal)
+	s.Require().Equal(s.et.PublicVal, testVal)
 
 	tests := []struct {
 		n        int


### PR DESCRIPTION
Running `go test ./pkg/...` is failing due to a bad field reference on the `exampletypeSuite` struct.

If this is intentional, feel free to decline and close this PR!